### PR TITLE
Add more maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,3 +57,7 @@ about:
 extra:
   recipe-maintainers:
     - ocefpaf
+    - johanneskoester
+    - bgruening
+    - daler
+    - jdblischak


### PR DESCRIPTION
The CircleCI build for R 3.3.2 [failed](https://circleci.com/gh/conda-forge/r-rastervis-feedstock/2) due to an error during the upload to Anaconda Cloud. I can only restart a CircleCI build if I am listed as a maintainer of the feedstock.